### PR TITLE
(core): fix XML configuration parsing

### DIFF
--- a/libs/core/service/AppConfigManager.cpp
+++ b/libs/core/service/AppConfigManager.cpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2009-2021 IRCAD France
- * Copyright (C) 2012-2020 IHU Strasbourg
+ * Copyright (C) 2012-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -149,7 +149,10 @@ void AppConfigManager::create()
     this->createObjects(m_cfgElem);
     this->createConnections();
     const auto configTree = core::runtime::Convert::toPropertyTree(m_cfgElem);
-    this->createServices(configTree.get_child("config"));
+    if(configTree.count("config"))
+    {
+        this->createServices(configTree.get_child("config"));
+    }
 
     m_state = STATE_CREATED;
 }

--- a/libs/core/service/helper/Config.cpp
+++ b/libs/core/service/helper/Config.cpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2009-2021 IRCAD France
- * Copyright (C) 2012-2020 IHU Strasbourg
+ * Copyright (C) 2012-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -338,7 +338,6 @@ service::IService::Config Config::parseService(
     {
         const auto srvCfgFactory = service::extension::Config::getDefault();
         srvConfig.m_config = srvCfgFactory->getServiceConfig(config, srvConfig.m_type);
-        boost::property_tree::ptree cfgElem = core::runtime::Convert::toPropertyTree(srvConfig.m_config);
     }
     else
     {

--- a/libs/core/service/test/tu/AppConfigTest.cpp
+++ b/libs/core/service/test/tu/AppConfigTest.cpp
@@ -1390,6 +1390,7 @@ void AppConfigTest::parameterReplaceTest()
     CPPUNIT_ASSERT(srvInSubConfig->getIsUpdated());
 }
 
+//------------------------------------------------------------------------------
 
 void AppConfigTest::objectConfigTest()
 {
@@ -1421,8 +1422,6 @@ void AppConfigTest::objectConfigTest()
     CPPUNIT_ASSERT_EQUAL(std::string("value1"), config.get<std::string>("param1"));
     CPPUNIT_ASSERT_EQUAL(std::string("value2"), config.get<std::string>("param2"));
 }
-
-//------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
 

--- a/libs/core/service/test/tu/AppConfigTest.cpp
+++ b/libs/core/service/test/tu/AppConfigTest.cpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2009-2021 IRCAD France
- * Copyright (C) 2012-2020 IHU Strasbourg
+ * Copyright (C) 2012-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -40,6 +40,7 @@
 
 #include <data/Boolean.hpp>
 #include <data/Image.hpp>
+#include <data/String.hpp>
 
 #include <utest/wait.hpp>
 
@@ -1388,6 +1389,40 @@ void AppConfigTest::parameterReplaceTest()
     fwTestWaitMacro(srvInSubConfig->getIsUpdated());
     CPPUNIT_ASSERT(srvInSubConfig->getIsUpdated());
 }
+
+
+void AppConfigTest::objectConfigTest()
+{
+    m_appConfigMgr = this->launchAppConfigMgr("objectConfigTest");
+
+    // =================================================================================================================
+    // Test a service with an external configuration and test Composite with sub-object parsing
+    // =================================================================================================================
+
+    auto compo1 = std::dynamic_pointer_cast<data::Composite>(core::tools::fwID::getObject("compo1Id"));
+    CPPUNIT_ASSERT(compo1 != nullptr);
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), compo1->count("dataInComposite"));
+    auto data2 = compo1->at<data::String>("dataInComposite");
+    CPPUNIT_ASSERT(data2);
+    CPPUNIT_ASSERT_EQUAL(std::string("data2Id"), data2->getID());
+    CPPUNIT_ASSERT_EQUAL(std::string("Hello"), data2->value());
+
+    // This service should have a composite data and contain an external configuration with 2 parameters
+    core::tools::Object::sptr service = core::tools::fwID::getObject("TestService1Uid");
+    auto srv1                         = service::ut::TestService::dynamicCast(service);
+    CPPUNIT_ASSERT(srv1 != nullptr);
+    CPPUNIT_ASSERT_EQUAL(service::IService::CONFIGURED, srv1->getConfigurationStatus());
+
+    auto srvData1 = srv1->getLockedInput<data::Composite>("data1");
+    CPPUNIT_ASSERT(srvData1);
+    CPPUNIT_ASSERT(compo1 == srvData1.get_shared());
+
+    auto config = srv1->getConfigTree();
+    CPPUNIT_ASSERT_EQUAL(std::string("value1"), config.get<std::string>("param1"));
+    CPPUNIT_ASSERT_EQUAL(std::string("value2"), config.get<std::string>("param2"));
+}
+
+//------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
 

--- a/libs/core/service/test/tu/AppConfigTest.hpp
+++ b/libs/core/service/test/tu/AppConfigTest.hpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2009-2021 IRCAD France
- * Copyright (C) 2012-2019 IHU Strasbourg
+ * Copyright (C) 2012-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -47,6 +47,7 @@ CPPUNIT_TEST(optionalKeyTest);
 CPPUNIT_TEST(keyGroupTest);
 CPPUNIT_TEST(concurentAccessToAppConfigTest);
 CPPUNIT_TEST(parameterReplaceTest);
+CPPUNIT_TEST(objectConfigTest);
 CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -64,6 +65,7 @@ public:
     void keyGroupTest();
     void concurentAccessToAppConfigTest();
     void parameterReplaceTest();
+    void objectConfigTest();
 
 private:
 

--- a/libs/core/service/test/tu/rc/AppConfigTest/plugin.xml
+++ b/libs/core/service/test/tu/rc/AppConfigTest/plugin.xml
@@ -369,4 +369,35 @@
     </extension>
 
 
+    <extension implements="::sight::service::extension::AppConfig">
+        <id>objectConfigTest</id>
+        <desc>Test configuration for start and stop</desc>
+        <config>
+
+            <object uid="compo1Id" type="sight::data::Composite">
+                <item key="dataInComposite">
+                    <object uid="data2Id" type="sight::data::String">
+                        <value>Hello</value>
+                    </object>
+                </item>
+            </object>
+
+            <service uid="TestService1Uid" type="sight::service::ut::TestServiceImplementation" config="serviceConfigTest">
+                <in key="data1" uid="compo1Id" />
+            </service>
+
+            <start uid="TestService1Uid" />
+
+        </config>
+    </extension>
+
+    <extension implements="sight::service::extension::Config">
+        <id>serviceConfigTest</id>
+        <service>sight::service::ut::TestServiceImplementation</service>
+        <desc>service configuration for unit test</desc>
+        <config>
+            <param1>value1</param1>
+            <param2>value2</param2>
+        </config>
+    </extension>
 </plugin>


### PR DESCRIPTION
## Description

Fix the parsing of object containing sub-object (like Composite) or values (like String).
Also fix the pasing of service with an external configuration ("config" tag in the XML service definition).

## How to test it?

- Launch unit tests.
- Try to add `config="..."` in a service with inputs (like a reader).
- Try to use a Composite with sub-object (like composite of transfer functions).