### PR TITLE
(ui): delete sequencer data when going backward

### DIFF
--- a/libs/core/activity/IActivitySequencer.cpp
+++ b/libs/core/activity/IActivitySequencer.cpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2019-2021 IRCAD France
- * Copyright (C) 2019 IHU Strasbourg
+ * Copyright (C) 2019-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -66,8 +66,8 @@ int IActivitySequencer::parseActivities(const data::SeriesDB::sptr& seriesDB)
             helper.remove(series);
             helper.notify();
         }
-        else if(!(lastActivityIndex + 1 < m_activityIds.size()
-                  && m_activityIds[lastActivityIndex + 1] == activity->getActivityConfigId()))
+        else if(!(static_cast<size_t>(lastActivityIndex + 1) < m_activityIds.size()
+                  && m_activityIds[static_cast<size_t>(lastActivityIndex + 1)] == activity->getActivityConfigId()))
         {
             // Remove the wrong data
             SIGHT_ERROR("The activity '" + activity->getActivityConfigId() + "' is unknown, it will be removed")
@@ -257,6 +257,30 @@ data::ActivitySeries::sptr IActivitySequencer::getActivity(
     }
 
     return activity;
+}
+
+//------------------------------------------------------------------------------
+
+void IActivitySequencer::clearLastActivities(const data::SeriesDB::sptr& seriesDB, size_t index)
+{
+    if(seriesDB->size() > index)
+    {
+        data::helper::SeriesDB helper(seriesDB);
+
+        // remove the last activities
+        while(seriesDB->size() > index)
+        {
+            const auto activity = seriesDB->back();
+            helper.remove(activity);
+        }
+
+        helper.notify();
+
+        // clear the requirements and parse the remaining activities to regereate the requirements with the existing
+        // activities
+        m_requirements.clear();
+        this->parseActivities(seriesDB);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/libs/core/activity/IActivitySequencer.hpp
+++ b/libs/core/activity/IActivitySequencer.hpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2019-2021 IRCAD France
- * Copyright (C) 2019 IHU Strasbourg
+ * Copyright (C) 2019-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -83,6 +83,19 @@ protected:
         size_t index,
         const core::com::SlotBase::sptr& slot   = nullptr,
         const data::Composite::csptr& overrides = nullptr
+    );
+
+    /**
+     * @brief Remove the activity with index and its requirements and all the following activities.
+     *
+     * This is used to clear the series and requirement when going backward.
+     *
+     * @param seriesDB Series DB containing all the activities
+     * @param index the activity in index and all the following will be removed
+     */
+    ACTIVITY_API void clearLastActivities(
+        const data::SeriesDB::sptr& seriesDB,
+        size_t index
     );
 
     /// List of the activity to create.

--- a/modules/ui/qt/activity/SSequencer.hpp
+++ b/modules/ui/qt/activity/SSequencer.hpp
@@ -1,7 +1,7 @@
 /************************************************************************
  *
  * Copyright (C) 2016-2021 IRCAD France
- * Copyright (C) 2016-2019 IHU Strasbourg
+ * Copyright (C) 2016-2021 IHU Strasbourg
  *
  * This file is part of Sight.
  *
@@ -45,10 +45,17 @@ namespace activity
  * The order of the activities is given in the configuration.
  *
  * ActivitySeries are created for each activity using the data produced by the previous activities. This activities are
- * stored in the current SeriesDB.
+ * stored in the current SeriesDB. By default all the data are stored, you can to backward and forward as you want in
+ * the existing activities. Using the tag 'clearActivities', you can remove the last activities when going backward to
+ * force the user to re-generate the data.
  *
  * @warning If an activity can not be launched with the existing parameters, the signal 'dataRequired' is emitted. It
  * can be connected to an activity wizard to add the missing data, or you can supplied 'requirementOverrides' composite.
+ *
+ * @note If the inout SeriesDB already contains activities, their are parsed and the sequencer open on the last
+ * activities. Be careful to store them in the right order.
+ *
+ * @warning If the SeriesDB contains other series (or unkonwn activities), they are removed with a simple log error.
  *
  * @section Signal Signal
  * - \b activityCreated(data::ActivitySeries::sptr) : This signal is emitted when an activity is created (using
@@ -73,6 +80,7 @@ namespace activity
         <activity id="..." name="..." />
         <activity id="..." name="..." />
         <activity id="..." name="..." />
+        <clearActivities>false</cleanActivities>
         <clear>#FFFFFF</clear>
         <theme>#FF00FF</theme>
         <accent>#FF00FF</accent>
@@ -95,7 +103,9 @@ namespace activity
  *     - \b id: id of the activities to launch. The first activity in the list is the first that will be launched.
  *     - \b name(optional): name of the activity to display in the editor. If it is empty, the the activity's will be
  *          used
- * - \b theme (optional, lihgt/dark): the global theme used by the sequencer.
+ * - \b clearActivities (optional, default: false): define if the activities and their requirements should be removed
+ * when going backward.
+ * - \b theme (optional, light/dark): the global theme used by the sequencer.
  * - \b clear (optional): the color of the opengl background scene.
  * - \b accent (optional): the accent color used by the sequencer.
  * - \b foreground (optional): the foreground color used by the sequencer.
@@ -178,15 +188,23 @@ private:
     /// Invoke 'enableActivity' method in Qml file
     void enableActivity(int index);
 
+    /// Invoke 'disableActivity' method in Qml file
+    void disableActivity(int index);
+
     ActivityCreatedSignalType::sptr m_sigActivityCreated;
     DataRequiredSignalType::sptr m_sigDataRequired;
     EnabledPreviousSignalType::sptr m_sigEnabledPrevious;
     EnabledNextSignalType::sptr m_sigEnabledNext;
 
+    /// List of the activities
     std::vector<std::string> m_activityNames;
 
     QPointer<QQuickWidget> m_widget;
 
+    /// Define if the activities should be cleared when going backward
+    bool m_clearActivities {false};
+
+    /// Colors used to customize sequencer
     std::string m_theme;
     std::string m_accent;
     std::string m_clear;

--- a/modules/ui/qt/rc/ActivitySequencer.qml
+++ b/modules/ui/qt/rc/ActivitySequencer.qml
@@ -17,6 +17,10 @@ Item{
         repeater.itemAt(index).enabled = true
     }
 
+    function disableActivity(index){
+        repeater.itemAt(index).enabled = false
+    }
+
     function setCurrentActivity(index){
         currentSelection = index
     }
@@ -27,7 +31,6 @@ Item{
         Material.foreground =  (foreground != "") ? foreground : Material.color(Material.BlueGrey, Material.Shade900)
         Material.background = (background != "") ? background : Material.background
         Material.primary = (primary != "") ? primary : Material.color(Material.Teal)
-        Material.elevation = (elevation != "") ? elevation : Material.elevation
     }
 
     RowLayout {
@@ -55,10 +58,14 @@ Item{
                     text : modelData
 
                     onClicked: {
-                        activitySelected(index)
-                        activitySequencer.currentSelection = index
+                        if (activitySequencer.currentSelection !== index)
+                        {
+                            activitySelected(index)
+                        }
                     }
                     background: Rectangle {
+                        implicitWidth: 200
+                        implicitHeight: 50
                         color: {
                             var color = Material.background
                             if(activitySequencer.currentSelection === index)


### PR DESCRIPTION
## Description

Add an option to remove all the data generated when going backward with the sequencer.
- display a dialog to inform the user that the data will be remove and ask to continue.
- remove all the following activities and their data.
- disable the following activities.

Also fix a few layout problem, the buttons required a width to be properly displayed.

## How to test it?

Add the tag  <clearActivities>true</clearActivities> in your sequencer configuration (for example in ExActivities). Test to go forward and backward.
Check that the sequencer still work as before without the option.
